### PR TITLE
Fix values structure not accesible

### DIFF
--- a/src/prompts/PrevCaller.hx
+++ b/src/prompts/PrevCaller.hx
@@ -1,3 +1,3 @@
 package prompts;
 
-typedef PrevCaller<T, R> = (prev:Dynamic, values:{ }, prompt:PromptObject<String>) -> R;
+typedef PrevCaller<T, R> = (prev:Dynamic, values: Dynamic, prompt:PromptObject<String>) -> R;


### PR DESCRIPTION
When using a function for the `value` property of a question, there was an issue with the `values` argument not allowing access to the anonymous structure properties, so a temporary fix by changing the type to Dynamic will have to suffice for now.